### PR TITLE
remove experimental flag

### DIFF
--- a/tmx
+++ b/tmx
@@ -27,7 +27,7 @@ fi
 
 base_session="$1"
 # This actually works without the trim() on all systems except OSX
-tmux_nb=$(trim `tmux ls | grep -P "^$base_session" | wc -l`)
+tmux_nb=$(trim `tmux ls | grep "^$base_session" | wc -l`)
 if [[ "$tmux_nb" == "0" ]]; then
     echo "Launching tmux base session $base_session ..."
     tmux new -s $base_session


### PR DESCRIPTION
-P is using PREG, which this particular regex is not. It will also serve for better portability.
