### PR TITLE
dev/misc-fixes

### DIFF
--- a/tmx
+++ b/tmx
@@ -27,7 +27,7 @@ fi
 
 base_session="$1"
 # This actually works without the trim() on all systems except OSX
-tmux_nb=$(trim `tmux ls | grep "^$base_session" | wc -l`)
+tmux_nb=$(trim `tmux ls | grep -c "^$base_session"`)
 if [[ "$tmux_nb" == "0" ]]; then
     echo "Launching tmux base session $base_session ..."
     tmux new-session -s $base_session

--- a/tmx
+++ b/tmx
@@ -27,7 +27,7 @@ fi
 
 base_session="$1"
 # This actually works without the trim() on all systems except OSX
-tmux_nb=$(trim `tmux ls | grep -c "^$base_session"`)
+tmux_nb=$(trim `tmux list-sessions -F '#{session_name}' | grep -c "^$base_session$"`)
 if [[ "$tmux_nb" == "0" ]]; then
     echo "Launching tmux base session $base_session ..."
     tmux new-session -s $base_session
@@ -35,7 +35,7 @@ else
     # Make sure we are not already in a tmux session
     if [[ -z "$TMUX" ]]; then
         # Kill defunct sessions first
-        old_sessions=$(tmux ls 2>/dev/null | egrep "^[0-9]{14}.*[0-9]+\)$" | cut -f 1 -d:)
+        old_sessions=$(tmux list-sessions -F '#{?session_attached,,#{?session_grouped,,#{session_name}}}' 2>/dev/null)
         for old_session_id in $old_sessions; do
             tmux kill-session -t $old_session_id
         done

--- a/tmx
+++ b/tmx
@@ -43,7 +43,7 @@ else
         echo "Launching copy of base session $base_session ..."
         # Session is is date and time to prevent conflict
         session_id=`date +%Y%m%d%H%M%S`
-        # Create a new session (without attaching it) and link to base session 
+        # Create a new session (without attaching it) and link to base session
         # to share windows
         tmux new-session -d -t $base_session -s $session_id
         # Attach to the new session
@@ -51,5 +51,4 @@ else
         # When we detach from it, kill the session
         tmux kill-session -t $session_id
     fi
-fi 
-
+fi


### PR DESCRIPTION
Newer tmux versions (trunk, but will be in 1.6) support using format strings to get exact output for listing sessions and the like. This allows the grep formats to be much simpler and precise.

Also some other tweaks (trailing space and using grep -c instead of grep | wc -l).
